### PR TITLE
Moving returnFunds functionality from settle to close 

### DIFF
--- a/contracts/ETHChannel.sol
+++ b/contracts/ETHChannel.sol
@@ -42,6 +42,7 @@ contract ETHChannel
     * @param _s Cryptographic param s derived from the signature.
     */
     function close(
+        bool _refundAmount,
         uint _nonce,
         uint256 _amount,
         uint8 _v,
@@ -49,7 +50,7 @@ contract ETHChannel
         bytes32 _s)
         external
     {
-        channelData_.close(address(this), _nonce, _amount, _v,_r,_s);
+        channelData_.close(address(this), _refundAmount, _nonce, _amount, _v,_r,_s);
         emit LogChannelClosed(block.number, msg.sender, _amount);
     }
 
@@ -86,24 +87,19 @@ contract ETHChannel
     /**
     * @notice After the timeout of the channel after closing has passed, can be called by either participant to withdraw funds.
     */
-    function settle(bool _returnBalance)
+    function settle()
         external
     {
-        channelData_.settle(address(this), _returnBalance);
+        channelData_.settle(address(this));
     }
 
-    function deposit(uint256 amountToDeposit) public payable 
-    { 
-        require(amountToDeposit > 0 ); 
+    function getBalance () public view returns (uint balance)
+    {
+        return address(this).balance;
     }
 
-    function getBalance () public view returns (uint balance)  
-    { 
-        return address(this).balance; 
-    }
-
-    //Fallback function for user to send funds 
-    function() public payable 
+    //Fallback function for user to send funds
+    function() public payable
     {
     }
 

--- a/contracts/ETHChannelLibrary.sol
+++ b/contracts/ETHChannelLibrary.sol
@@ -78,8 +78,8 @@ library ETHChannelLibrary
         require(signerAddress!=msg.sender);
         data.owingRecipient = _amount;
         data.closedNonce_ = _nonce;
+        data.returnFunds_ = _returnFunds;         
         data.closedBlock_ = block.number;
-        data.returnFunds_ = _returnFunds; 
     }
 
     /**

--- a/contracts/ETHChannelLibrary.sol
+++ b/contracts/ETHChannelLibrary.sol
@@ -14,6 +14,7 @@ library ETHChannelLibrary
         uint256 owingRecipient;
         uint closedBlock_;
         uint closedNonce_;
+        bool returnFunds_; 
     }
 
     event LogChannelSettled(uint blockNumber, address user);
@@ -61,6 +62,7 @@ library ETHChannelLibrary
     function close(
         ETHChannelData storage data,
         address _channelAddress,
+        bool _returnFunds,
         uint _nonce,
         uint256 _amount,
         uint8 _v,
@@ -77,6 +79,7 @@ library ETHChannelLibrary
         data.owingRecipient = _amount;
         data.closedNonce_ = _nonce;
         data.closedBlock_ = block.number;
+        data.returnFunds_ = _returnFunds; 
     }
 
     /**
@@ -126,7 +129,7 @@ library ETHChannelLibrary
     * @notice After the timeout of the channel after closing has passed, can be called by either participant to withdraw funds.
     * @param data The channel specific data to work on.
     */
-    function settle(ETHChannelData storage data, address _channelAddress, bool _returnFunds)
+    function settle(ETHChannelData storage data, address _channelAddress)
         public
         channelAlreadyClosed(data)
         timeoutOver(data)
@@ -144,13 +147,14 @@ library ETHChannelLibrary
             address(data.recipientAddress_).transfer(owedAmount);
         }
 
-        if(returnToUserAmount > 0 && _returnFunds)
+        if(returnToUserAmount > 0 && data.returnFunds_)
         {
             address(data.userAddress_).transfer(returnToUserAmount);
         }
 
         emit LogChannelSettled(block.number, data.userAddress_);
     }
+
 
     /**
     * @notice After the timeout of the channel after closing has passed, can be called by either participant to withdraw funds.


### PR DESCRIPTION
 - Changed smart contract to accept bool as parameter in the close function 
 - Changed tests to account for difference in parameters 
